### PR TITLE
on failure, don't emit successful exit status

### DIFF
--- a/src/main/java/se/cbb/jprime/apps/genphylodata/BranchRelaxer.java
+++ b/src/main/java/se/cbb/jprime/apps/genphylodata/BranchRelaxer.java
@@ -105,7 +105,7 @@ public class BranchRelaxer implements JPrIMEApp {
 			do {
 				if (attempts > params.maxAttempts) {
 					System.err.println("Failed to create valid rates within max allowed attempts.");
-					System.exit(0);
+					System.exit(1);
 				}
 				rates = model.getRates(t, names, origLengths);
 				attempts++;

--- a/src/main/java/se/cbb/jprime/apps/genphylodata/GuestTreeGen.java
+++ b/src/main/java/se/cbb/jprime/apps/genphylodata/GuestTreeGen.java
@@ -89,7 +89,7 @@ public class GuestTreeGen implements JPrIMEApp {
 					outinfo.close();
 				}
 				System.err.println("Failed to produce valid pruned tree within max allowed attempts.");
-				System.exit(0);
+				System.exit(1);
 			}
 			
 			// Print output.

--- a/src/main/java/se/cbb/jprime/apps/genphylodata/HostTreeGen.java
+++ b/src/main/java/se/cbb/jprime/apps/genphylodata/HostTreeGen.java
@@ -98,7 +98,7 @@ public class HostTreeGen implements JPrIMEApp {
 					outinfo.close();
 				}
 				System.err.println("Failed to produce valid pruned tree within max allowed attempts.");
-				System.exit(0);
+				System.exit(1);
 			}
 			
 			// Fix stem override.


### PR DESCRIPTION
`System.exit(0)` should only indicate a [successful exit](http://tldp.org/LDP/abs/html/exit-status.html). Using exit status of 1 to be consistent with other parts of the codebase.

